### PR TITLE
Update CSS for Android tablets (static kmw-key-square element)

### DIFF
--- a/source/resources/osk/kmwosk.css
+++ b/source/resources/osk/kmwosk.css
@@ -36,7 +36,7 @@
 .phone .kmw-key-layer-group{position:fixed;left:0;bottom:0;width:100%;margin:0;padding:1px 0;border:none;background-color:#999999;}
 .phone .kmw-key-layer{position:fixed;left:0;bottom:0;width:100%;height:100%;margin:0;padding:0;background-color:transparent;overflow:hidden;}
 .phone .kmw-key-row {position:fixed;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
-.phone .kmw-key-square {position:fixed;display:inline-block;height:100%;max-height:100%;overflow:hidden;margin:0 0 0 0;z-index: 10000;padding:0 0 0 0;background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
+.phone .kmw-key-square {position:fixed; display:inline-block;height:100%;max-height:100%;overflow:visible; margin:0 0 0 0;z-index: 10000;padding:0 0 0 0;background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 .phone .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001;padding:0; background-color:transparent;cursor:default;}
 .phone .kmw-key {display:block;position:fixed;margin:0px;border-radius:6px;text-align:center; box-sizing:border-box; overflow:hidden;
         border:solid 2px #999999;
@@ -53,7 +53,6 @@
 
 .phone.ios .kmw-key-layer-group {background-color: #cfd3d9}
 .phone.ios .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 5px;}
-.phone.ios .kmw-key-square {overflow:visible;}
 .phone.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;} 
 .phone.ios .kmw-key.kmw-key-shift {color:#fff;background-color:#b2b9c5;} 
 .phone.ios .kmw-key.kmw-key-shift-on {color:#000;background-color:#fdfdfe;} 
@@ -61,7 +60,6 @@
  
 .phone.android .kmw-key-layer-group {background-color: #333;}  
 .phone.android .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 3px;}
-.phone.android .kmw-key-square {position:static;} /* 4.3 needs static, not fixed */
 .phone.android .kmw-key.kmw-key-default {color:#fff;background-color:#777;} 
 .phone.android .kmw-key.kmw-key-shift {color:#fff;background-color:#555;} 
 .phone.android .kmw-key.kmw-key-shift-on {color:#000;background-color:#ddd;} 
@@ -78,7 +76,7 @@
 .tablet .kmw-key-row {position:fixed;width:100%;height:20%;margin:0;padding:0;border:none;overflow:hidden;}
 .tablet .kmw-key-square {position:fixed; display:inline-block; height:100%; max-height:100%; overflow:hidden; margin:0 0 0 0; z-index: 10000; padding:0 0 0 0; background-color:transparent;cursor:default; border:none;-webkit-tap-highlight-color:rgba(0,0,0,0)}
 .tablet .kmw-key-square-ex {display:inline-block;box-sizing:border-box;margin:0 0 0 5px;z-index:10001; padding:0; background-color:transparent; cursor:default;}  
-.tablet .kmw-key {display:block;position:fixed;margin:2px;border-radius:8px;text-align:center;box-sizing:border-box;overflow:hidden;
+.tablet .kmw-key {display:block;position:fixed;margin:2px;border-radius:8px;text-align:center;box-sizing:border-box;overflow:visible;
         border:solid 2px #999999;
         box-shadow: 0px -1px 1px 0px rgba(0,0,0,1) inset;
  }
@@ -88,7 +86,6 @@
 
 .tablet.ios .kmw-key-layer-group {background-color: #cfd3d9}
 .tablet.ios .kmw-key {border: none; border-bottom: solid 1px #8a8d90; box-shadow:none; border-radius: 5px;}
-.tablet.ios .kmw-key-square {overflow:visible;}
 .tablet.ios .kmw-key.kmw-key-default {color:#000;background-color:#fdfdfe;} 
 .tablet.ios .kmw-key.kmw-key-shift {color:#fff;background-color:#b2b9c5;} 
 .tablet.ios .kmw-key.kmw-key-shift-on {color:#000;background-color:#fdfdfe;} 
@@ -97,7 +94,6 @@
 .tablet .kmw-key-row {-webkit-touch-callout:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 
 .tablet.android .kmw-key-layer-group {background-color: #b4b4b8; border-top: 1px solid #666;}
-.tablet.android .kmw-key-square {overflow:visible; position:static;} /* 4.3 needs static, not fixed */
 .tablet.android .kmw-key {border: none; border: solid 1px #111; box-shadow:0px 2px 5px #888; border-radius: 3px;}
 .tablet.android .kmw-key.kmw-key-default {color:#000;background-color:#ddd;} 
 .tablet.android .kmw-key.kmw-key-shift {color:#77f;background-color:#a8a8a8;} 

--- a/source/resources/osk/kmwosk.css
+++ b/source/resources/osk/kmwosk.css
@@ -97,7 +97,7 @@
 .tablet .kmw-key-row {-webkit-touch-callout:none;-webkit-user-select:none;-ms-user-select:none;user-select:none;-webkit-tap-highlight-color:rgba(0,0,0,0);}
 
 .tablet.android .kmw-key-layer-group {background-color: #b4b4b8; border-top: 1px solid #666;}
-.tablet.android .kmw-key-square {overflow:visible;}
+.tablet.android .kmw-key-square {overflow:visible; position:static;} /* 4.3 needs static, not fixed */
 .tablet.android .kmw-key {border: none; border: solid 1px #111; box-shadow:0px 2px 5px #888; border-radius: 3px;}
 .tablet.android .kmw-key.kmw-key-default {color:#000;background-color:#ddd;} 
 .tablet.android .kmw-key.kmw-key-shift {color:#77f;background-color:#a8a8a8;} 


### PR DESCRIPTION
Fix Android 4.1-4.3 CSS rules to handle anomalies in Android Browser with the kmw-key-square elements