### PR TITLE
Fix KC context check when before start of text store

### DIFF
--- a/source/kmwnative.js
+++ b/source/kmwnative.js
@@ -187,8 +187,9 @@
       }
       if(LselectionStart < n)
       {
-//dbg(n+' '+ln+' '+Pelem.value._kmwSubstring(0,LselectionStart));
-        return Pelem.value._kmwSubstr(0,LselectionStart); //I3319, KMW-1
+        // Looking for context before start of text buffer so return non-characters to pad result
+        var tempContext = Array(n-LselectionStart+1).join("\uFFFE") + Pelem.value._kmwSubstr(0,LselectionStart);
+        return tempContext._kmwSubstr(0,ln);
       }
 //dbg(n+' '+ln+' '+Pelem.value._kmwSubstring(LselectionStart-n,LselectionStart-n+ln));
       return Pelem.value._kmwSubstring(LselectionStart-n,LselectionStart-n+ln); //I3319, KMW-1


### PR DESCRIPTION
If a context check is performed before the beginning of a text store, the KC function returns the wrong results, on mozilla style browsers.

The following example will currently match wrongly on "a" and will return "aa".

```
  store(s1) "a"
  any(s1) any(s1) > context(1) context(2) 
```

The proposed fix pads the context with U+FFFE (non-character) to ensure that the correct length and part of the context is returned. The portion before the start of the text store will then be non-characters. This should then mean that the KA function will not match (unless the U+FFFE is actually used by the keyboard author, which is not recommended in any case).